### PR TITLE
add build stage to prepare to allow installing directly from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fix": "eslint --fix src/ --ext .ts",
     "lint": "eslint src/ --ext .ts",
     "test": "jest",
-    "prepare": "husky install",
+    "prepare": "npm run build && husky install",
     "docs": "typedoc src/ --readme none"
   },
   "repository": {


### PR DESCRIPTION
This allows installation directly from Github.
Since WhatsApp releases breaking changes frequently, this will allow people to quickly use fixes in production without having to wait for the npm package to be released